### PR TITLE
Try to open memory used file from cgroups2 first by defauilt

### DIFF
--- a/test/preoomkiller_test.rb
+++ b/test/preoomkiller_test.rb
@@ -58,7 +58,11 @@ describe 'Preoomkiller' do
   end
 
   it "points to the missing used file when failing" do
-    preoomkiller("-i 0 echo 1", success: false).must_equal "Could not open /sys/fs/cgroup/memory/memory.usage_in_bytes\n"
+    preoomkiller("-i 0 echo 1", success: false).must_equal "Could not open /sys/fs/cgroup/memory.current or /sys/fs/cgroup/memory/memory.usage_in_bytes\n"
+  end
+
+  it "points to the missing optional used file when failing" do
+    preoomkiller("-u test/fixtures/doesnt_exist.txt -i 0 echo 1", success: false).must_equal "Could not open test/fixtures/doesnt_exist.txt\n"
   end
 
   it "points to the missing max file when failing" do


### PR DESCRIPTION
Kubernetes v1.26 uses cgroups2 by default. The default endpoints for memory usage has changed from "/sys/fs/cgroup/memory/memory.usage_in_bytes" to "/sys/fs/cgroup/memory.current"

If a usage file is not specified, this checks for the existence of the cgroups2 path by default and falls back to the cgroups1 path.